### PR TITLE
fix: dev-test-slots script formatting

### DIFF
--- a/backend/app/crud/booking.py
+++ b/backend/app/crud/booking.py
@@ -5,6 +5,9 @@ from datetime import date as dt_date
 from app.models.booking import Booking
 from app.schemas.booking import BookingCreate
 
+from datetime import date
+from backend.app.models.booking import Booking
+
 
 def create_booking(db: Session, data: BookingCreate) -> Booking:
     booking = Booking(
@@ -27,3 +30,15 @@ def get_bookings_by_date(db: Session, day: dt_date) -> list[Booking]:
 def is_slot_taken(db: Session, day: dt_date, t) -> bool:
     stmt = select(Booking).where(Booking.date == day, Booking.time == t)
     return db.execute(stmt).scalar_one_or_none() is not None
+
+
+def get_booked_times_by_date(db: Session, booking_date: date):
+    """
+    Returns list of booked times as HH:MM strings
+    """
+    rows = (
+        db.query(Booking.time)
+        .filter(Booking.date == booking_date)
+        .all()
+    )
+    return [r[0].strftime("%H:%M") for r in rows]

--- a/scripts/dev-test-slots.sh
+++ b/scripts/dev-test-slots.sh
@@ -1,9 +1,3 @@
-
----
-
-## `scripts/dev-test-slots.sh`
-
-```bash
 #!/usr/bin/env bash
 set -e
 
@@ -16,4 +10,8 @@ fi
 
 echo "==> GET /slots (date=$DATE)"
 
-curl -s "http://localhost:8000/slots?date=$DATE" | jq .
+if command -v jq >/dev/null 2>&1; then
+  curl -s "http://localhost:8000/slots?date=$DATE" | jq .
+else
+  curl -s "http://localhost:8000/slots?date=$DATE"
+fi


### PR DESCRIPTION
## What
- Implement GET /slots endpoint
- Return structured slot availability (30-minute intervals)
- Exclude already booked slots
- Add dev-test-slots.sh for verification

## Verification
- ./scripts/dev-test-book.sh returns 409 on duplicate booking
- ./scripts/dev-test-slots.sh reflects unavailable slots correctly

## Evidence
- Booking at 10:00 marked unavailable in slots response

Closes #7