### PR TITLE
feat(db): enforce unique booking per date and time

### DIFF
--- a/backend/alembic/versions/90f541639493_db_enforce_unique_booking_per_date_and_time.py
+++ b/backend/alembic/versions/90f541639493_db_enforce_unique_booking_per_date_and_time.py
@@ -1,0 +1,32 @@
+"""db: enforce unique booking per date and time
+
+Revision ID: 90f541639493
+Revises: 5b82075df3f6
+Create Date: 2026-01-23
+"""
+
+from alembic import op
+
+# Revision identifiers, used by Alembic.
+revision = "90f541639493"
+down_revision = "5b82075df3f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Prevent double-booking by enforcing uniqueness on (date, time)
+    op.create_unique_constraint(
+        "uq_bookings_date_time",
+        "bookings",
+        ["date", "time"],
+    )
+
+
+def downgrade() -> None:
+    # Remove the unique constraint
+    op.drop_constraint(
+        "uq_bookings_date_time",
+        "bookings",
+        type_="unique",
+    )


### PR DESCRIPTION
## What
- Add DB unique constraint on bookings(date, time)

## Why
- Prevent double-booking at the database level

## Verification
- dev-test-book.sh returns 201 then 409 for the same slot
- alembic upgrade applied successfully (5b82075df3f6 -> 90f541639493)
